### PR TITLE
fix wrong name for generated cms element component, fixes #44

### DIFF
--- a/src/main/resources/fileTemplates/j2ee/cms/element/Shopware Element Component Index.js.ft
+++ b/src/main/resources/fileTemplates/j2ee/cms/element/Shopware Element Component Index.js.ft
@@ -3,7 +3,7 @@ import './sw-cms-el-component-${NAME}.scss';
 
 const {Component, Mixin} = Shopware;
 
-Component.register('sw-cms-el-${NAME}', {
+Component.register('sw-cms-el-component-${NAME}', {
     template,
 
     mixins: [


### PR DESCRIPTION
fix wrong name for generated cms element component, fixes #44