### PR TITLE
fix: update to IntelliJ Platform 2026.1 and fix failing tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,6 +143,18 @@ tasks {
     runIde {
         jvmArgs("-Xmx4000m")
     }
+
+    // The bundled Vue plugin fails to initialize its LSP service in the test IDE because it cannot
+    // resolve its language-server binary from the transformed distribution layout. That failure
+    // fires from VFS listeners as soon as a `.js` file is added to a fixture project and is promoted
+    // to a test failure. We don't use Vue, so disable the plugin in the test sandbox.
+    prepareTestSandbox {
+        val configDir = sandboxConfigDirectory
+        doLast {
+            configDir.get().asFile.resolve("disabled_plugins.txt")
+                .writeText("org.jetbrains.plugins.vue\n")
+        }
+    }
     processResources {
         exclude("fileTemplates/j2ee/**")
         from(fileTree("src/main/resources/fileTemplates/j2ee").files) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,22 +7,22 @@ pluginVersion=0.0.54
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=253
-pluginUntilBuild=261.*
+pluginSinceBuild=261
+pluginUntilBuild=262.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=IU-2025.3
+pluginVerifierIdeVersions=IU-2026.1
 platformType=IU
-platformVersion=2025.3
+platformVersion=2026.1
 platformDownloadSources=true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins=com.jetbrains.php:253.28294.325,com.jetbrains.twig:253.28294.322,fr.adrienbrault.idea.symfony2plugin:2025.1.281,de.espend.idea.php.annotation:12.0.2
+platformPlugins=com.jetbrains.php:261.26222.22,com.jetbrains.twig:261.22158.185,fr.adrienbrault.idea.symfony2plugin:2026.1.308,de.espend.idea.php.annotation:12.1.0
 
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins = JavaScript,Git4Idea,org.jetbrains.plugins.yaml,org.jetbrains.plugins.sass
+platformBundledPlugins = JavaScript,org.jetbrains.plugins.yaml,org.jetbrains.plugins.sass
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 9.2.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ junit = "4.13.2"
 
 # plugins
 changelog = "2.5.0"
-intelliJPlatform = "2.17.0"
+intelliJPlatform = "2.18.0"
 kotlin = "2.4.0"
 kover = "0.9.8"
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,7 +10,6 @@
     <depends>org.jetbrains.plugins.sass</depends>
     <depends>org.jetbrains.plugins.yaml</depends>
     <depends>JavaScript</depends>
-    <depends>Git4Idea</depends>
     <depends optional="true" config-file="de.shyim.shopware6.symfony.xml">fr.adrienbrault.idea.symfony2plugin</depends>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
## Summary

`./gradlew check` was failing after the `org.jetbrains.intellij.platform` 2.17.0 → 2.18.0 bump (#284 branch). This PR updates the target IDE to **2026.1** and fixes the underlying causes so the test suite passes again.

## Root causes & fixes

1. **Vue LSP static-initializer crash** — The bundled Vue plugin can't resolve its language-server binary from the Gradle-transformed IDE distribution (`.../vuejs-plugin/lib/modules should be lib directory`). Its LSP service throws in a static initializer from VFS listeners the moment a `.js` file is copied into a fixture project, and the test framework promotes that logged error to a failure. This broke the 7 tests that touch `.js`/`.twig` files. We don't use Vue → **disable the Vue plugin in the test sandbox** via a `disabled_plugins.txt` written by `prepareTestSandbox`.

2. **Unused Git4Idea dependency** — `plugin.xml` declared `<depends>Git4Idea</depends>` but no code uses any Git API. In 2026.1 Git4Idea fails to load (content-module id conflict with the bundled JetBrains Client Git plugin), which cascaded to disable our entire plugin so its indexes were never registered (`IllegalStateException: Index is not created`). **Removed the dead dependency** from both `plugin.xml` and `platformBundledPlugins`.

## Changes

- `gradle.properties`: platform `2025.3` → `2026.1`; `pluginSinceBuild`/`pluginUntilBuild` retargeted to `261`/`262.*`; marketplace plugin deps bumped to 2026.1-compatible builds (PHP `261.26222.22`, Twig `261.22158.185`, Symfony `2026.1.308`, PHP Annotations `12.1.0`); dropped `Git4Idea` from bundled plugins.
- `src/main/resources/META-INF/plugin.xml`: removed unused `<depends>Git4Idea</depends>`.
- `build.gradle.kts`: disable the Vue plugin in the test sandbox.

## Verification

- `./gradlew check` → **BUILD SUCCESSFUL**, all 11 tests pass (0 skipped / 0 failures / 0 errors).
- `./gradlew verifyPlugin` → plugin reported **Compatible**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)