### PR TITLE
Replace Apache Commons StringUtils with Kotlin stdlib

### DIFF
--- a/src/main/kotlin/de/shyim/shopware6/action/project/ConfigureShopwareProjectAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/project/ConfigureShopwareProjectAction.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import de.shyim.shopware6.util.ShopwareBundleUtil
 import icons.ShopwareToolBoxIcons
 import org.apache.commons.io.FileUtils
-import org.apache.commons.lang3.StringUtils
 import org.codehaus.jettison.json.JSONObject
 import java.io.File
 import com.intellij.notification.Notification
@@ -156,11 +155,7 @@ class ConfigureShopwareProjectAction : DumbAwareAction(
             var alreadyRegistered = false
 
             foundContentEntry.sourceFolders.forEach { sourceFolder ->
-                if (StringUtils.removeEnd(
-                        sourceFolder?.file.toString(),
-                        "/"
-                    ) == StringUtils.removeEnd(bundleFolder.toString(), "/")
-                ) {
+                if (sourceFolder?.file.toString().removeSuffix("/") == bundleFolder.toString().removeSuffix("/")) {
                     sourceFolder.packagePrefix = key
                     alreadyRegistered = true
                 }


### PR DESCRIPTION
## Summary
Replaced Apache Commons Lang `StringUtils.removeEnd()` calls with Kotlin's built-in `removeSuffix()` function, eliminating an unnecessary external dependency.

## Key Changes
- Removed unused import of `org.apache.commons.lang3.StringUtils`
- Replaced `StringUtils.removeEnd(sourceFolder?.file.toString(), "/")` with `sourceFolder?.file.toString().removeSuffix("/")`
- Replaced `StringUtils.removeEnd(bundleFolder.toString(), "/")` with `bundleFolder.toString().removeSuffix("/")`
- Simplified the conditional logic from 5 lines to a single line while maintaining identical functionality

## Implementation Details
The change leverages Kotlin's standard library `removeSuffix()` extension function, which provides the same behavior as Apache Commons' `removeEnd()` method. This reduces external dependencies and improves code readability by using idiomatic Kotlin.

https://claude.ai/code/session_01HgCBY3kYYWakLKYQXuyoQN