### PR TITLE
Add anonymous feature usage telemetry

### DIFF
--- a/src/main/kotlin/de/shyim/shopware6/action/context/InsertSnippetAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/context/InsertSnippetAction.kt
@@ -13,6 +13,7 @@ import com.intellij.ui.components.JBList
 import com.jetbrains.php.lang.psi.PhpFile
 import com.jetbrains.twig.TwigFile
 import de.shyim.shopware6.completion.SnippetCompletionElement
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.util.AdminSnippetUtil
 import de.shyim.shopware6.util.FrontendSnippetUtil
 import icons.ShopwareToolBoxIcons
@@ -24,6 +25,8 @@ class InsertSnippetAction : DumbAwareAction("Insert Snippet", "Insert snippet co
     override fun actionPerformed(e: AnActionEvent) {
         val pf: PsiFile = LangDataKeys.PSI_FILE.getData(e.dataContext) ?: return
         val editor = LangDataKeys.EDITOR.getData(e.dataContext) ?: return
+
+        val startedAt = System.currentTimeMillis()
 
         val items: MutableList<SnippetCompletionElement> = if (pf.virtualFile.path.contains("app/administration")) {
             AdminSnippetUtil.getAllEnglishKeys(pf.project)
@@ -76,6 +79,8 @@ class InsertSnippetAction : DumbAwareAction("Insert Snippet", "Insert snippet co
                             )
                     }, "Insert Snippet", null)
                 }
+
+                TelemetryClient.trackFeature(pf.project, "snippet.insert", startedAt)
             })
             .createPopup()
             .showInBestPositionFor(e.dataContext)

--- a/src/main/kotlin/de/shyim/shopware6/action/context/admin/ExtendAdminComponentAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/context/admin/ExtendAdminComponentAction.kt
@@ -23,6 +23,7 @@ import com.intellij.ui.components.JBList
 import de.shyim.shopware6.action.generator.ActionUtil
 import de.shyim.shopware6.action.generic.GenericSimpleDialogWrapper
 import de.shyim.shopware6.index.dict.ShopwareBundle
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.templates.ShopwareTemplates
 import de.shyim.shopware6.util.JavaScriptPattern
 import de.shyim.shopware6.util.PsiUtil
@@ -154,6 +155,8 @@ class ExtendAdminComponentAction : DumbAwareAction(
             project: Project,
             runnable: (String) -> Unit
         ) {
+            val startedAt = System.currentTimeMillis()
+
             val newComponentName: String
             val defaultFilePath = if (type == "override") {
                 newComponentName = componentName
@@ -214,6 +217,8 @@ class ExtendAdminComponentAction : DumbAwareAction(
 
             if (file != null) {
                 runnable(file.virtualFile.path)
+
+                TelemetryClient.trackFeature(project, "admin.extend_component.$type", startedAt)
             }
 
             val entryPoint = LocalFileSystem.getInstance().findFileByPath(bundle.getAdministrationEntrypoint())!!

--- a/src/main/kotlin/de/shyim/shopware6/action/context/admin/ExtendAdminComponentMethodAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/context/admin/ExtendAdminComponentMethodAction.kt
@@ -23,6 +23,7 @@ import com.intellij.ui.components.JBList
 import com.intellij.util.containers.filterSmartMutable
 import de.shyim.shopware6.index.dict.AdminComponent
 import de.shyim.shopware6.index.dict.ShopwareBundle
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.util.ShopwareBundleUtil
 import de.shyim.shopware6.util.StringUtil
 import icons.ShopwareToolBoxIcons
@@ -83,6 +84,8 @@ class ExtendAdminComponentMethodAction :
         private const val NEW_COMPONENT = "Create new component"
 
         fun extendMethod(element: PsiElement, editor: Editor) {
+            val startedAt = System.currentTimeMillis()
+
             val componentName = getComponentName(element)
 
             val popup = ShopwareBundleUtil.getBundleSelectionPopup(element.project)
@@ -130,9 +133,13 @@ class ExtendAdminComponentMethodAction :
                                 bundle
                             ) {
                                 addMethodToComponent(element, it)
+
+                                TelemetryClient.trackFeature(element.project, "admin.extend_method", startedAt)
                             }
                         } else {
                             addMethodToComponent(element, component.file)
+
+                            TelemetryClient.trackFeature(element.project, "admin.extend_method", startedAt)
                         }
                     }
 

--- a/src/main/kotlin/de/shyim/shopware6/action/copy/CopySnippet.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/copy/CopySnippet.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.ui.popup.PopupChooserBuilder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.ui.components.JBList
+import de.shyim.shopware6.telemetry.TelemetryClient
 import icons.ShopwareToolBoxIcons
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
@@ -19,6 +20,8 @@ class CopySnippet : DumbAwareAction("Copy Snippet Code", "Copy the snippet code"
         val pf: PsiFile = LangDataKeys.PSI_FILE.getData(e.dataContext) ?: return
         val editor = LangDataKeys.EDITOR.getData(e.dataContext) ?: return
         val pe = pf.findElementAt(editor.caretModel.offset) ?: return
+
+        val startedAt = System.currentTimeMillis()
 
         val key = resolveKey(pe)
         val collectionList: MutableCollection<String> = mutableListOf()
@@ -45,6 +48,8 @@ class CopySnippet : DumbAwareAction("Copy Snippet Code", "Copy the snippet code"
                         StringSelection(code),
                         null
                     )
+
+                TelemetryClient.trackFeature(pf.project, "snippet.copy", startedAt)
             })
             .createPopup()
             .showInBestPositionFor(editor)

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/NewConfigXmlAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/NewConfigXmlAction.kt
@@ -6,11 +6,14 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.templates.ShopwareTemplates
 
 class NewConfigXmlAction : DumbAwareAction("Create a Config.Xml", "Create a new config.xml", AllIcons.FileTypes.Xml) {
 
     override fun actionPerformed(e: AnActionEvent) {
+        val startedAt = System.currentTimeMillis()
+
         val project: Project? = e.getData(PlatformDataKeys.PROJECT)
 
         if (project === null) {
@@ -24,6 +27,8 @@ class NewConfigXmlAction : DumbAwareAction("Create a Config.Xml", "Create a new 
             "config.xml",
             XmlFileType.INSTANCE
         )
+
+        TelemetryClient.trackFeature(project, "generator.config_xml", startedAt)
     }
 
 }

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/app/AddCmsActions.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/app/AddCmsActions.kt
@@ -7,6 +7,7 @@ class AddCmsActions : AddConfigFileAction(
     "cms.xml",
     "Resources",
     ShopwareTemplates.SHOPWARE_APP_CMS,
+    "generator.app_cms_blocks",
     "Add CMS blocks",
     "Add CMS blocks to an app",
     ShopwareToolBoxIcons.SHOPWARE

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/app/AddConfigFileAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/app/AddConfigFileAction.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.PsiManager
 import com.intellij.ui.components.JBList
 import de.shyim.shopware6.action.generator.ActionUtil
 import de.shyim.shopware6.index.dict.ShopwareApp
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.templates.ShopwareTemplates
 import de.shyim.shopware6.util.ShopwareAppUtil
 import java.awt.Component
@@ -25,6 +26,7 @@ abstract class AddConfigFileAction(
     private val configFileName: String,
     private val configFilePath: String,
     private val shopwareTemplate: String,
+    private val telemetryFeature: String,
     text: String,
     description: String,
     icon: Icon
@@ -40,7 +42,8 @@ abstract class AddConfigFileAction(
             e.project!!,
             this.configFileName,
             this.configFilePath,
-            this.shopwareTemplate
+            this.shopwareTemplate,
+            System.currentTimeMillis()
         )
     }
 
@@ -48,7 +51,8 @@ abstract class AddConfigFileAction(
         project: Project,
         configFile: String,
         configFilePath: String,
-        shopwareTemplate: String
+        shopwareTemplate: String,
+        startedAt: Long
     ) {
         val apps = ShopwareAppUtil.getAllApps(project)
         val jbAppList = JBList(apps)
@@ -100,6 +104,8 @@ abstract class AddConfigFileAction(
 
                     FileEditorManager.getInstance(project)
                         .openTextEditor(OpenFileDescriptor(project, createdConfigFile.virtualFile), true)
+
+                    TelemetryClient.trackFeature(project, telemetryFeature, startedAt)
                 }, "Creating Config File", null)
             })
             .createPopup()

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/app/AddCustomEntitiesAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/app/AddCustomEntitiesAction.kt
@@ -7,6 +7,7 @@ class AddCustomEntitiesAction : AddConfigFileAction(
     "entities.xml",
     "Resources",
     ShopwareTemplates.SHOPWARE_APP_CUSTOM_ENTITIES,
+    "generator.app_custom_entities",
     "Add Custom Entities",
     "Add custom entities to an app",
     ShopwareToolBoxIcons.SHOPWARE

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/app/NewAppAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/app/NewAppAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.ui.Messages
 import de.shyim.shopware6.action.generator.ActionUtil
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.templates.ShopwareTemplates
 import icons.ShopwareToolBoxIcons
 
@@ -13,6 +14,8 @@ class NewAppAction : DumbAwareAction("Create an App", "Create a new Shopware app
         if (e.project == null) {
             return
         }
+
+        val startedAt = System.currentTimeMillis()
 
         val rootDirectory = ActionUtil.getViewDirectory(e.dataContext) ?: return
 
@@ -40,5 +43,7 @@ class NewAppAction : DumbAwareAction("Create an App", "Create a new Shopware app
             content,
             appFolder
         )
+
+        TelemetryClient.trackFeature(e.project, "generator.app", startedAt)
     }
 }

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/app/NewAppScriptAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/app/NewAppScriptAction.kt
@@ -13,6 +13,7 @@ import com.jetbrains.twig.TwigFileType
 import de.shyim.shopware6.action.generator.ActionUtil
 import de.shyim.shopware6.index.dict.ScriptHook
 import de.shyim.shopware6.index.dict.ShopwareApp
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.templates.ShopwareTemplates
 import de.shyim.shopware6.util.PsiUtil
 import de.shyim.shopware6.util.ScriptHookUtil
@@ -28,6 +29,8 @@ class NewAppScriptAction :
         if (e.project == null) {
             return
         }
+
+        val startedAt = System.currentTimeMillis()
 
         val hooks = ScriptHookUtil.getAllHooks(e.project!!)
 
@@ -57,13 +60,13 @@ class NewAppScriptAction :
                 return@setFilteringEnabled (it as ScriptHook).name
             }
             .setItemChosenCallback(Runnable {
-                this.chooseApp(jbHookList.selectedValue!!, e.project!!)
+                this.chooseApp(jbHookList.selectedValue!!, e.project!!, startedAt)
             })
             .createPopup()
             .showInFocusCenter()
     }
 
-    private fun chooseApp(scriptHook: ScriptHook, project: Project) {
+    private fun chooseApp(scriptHook: ScriptHook, project: Project, startedAt: Long) {
         val apps = ShopwareAppUtil.getAllApps(project)
         val jbAppList = JBList(apps)
 
@@ -89,7 +92,7 @@ class NewAppScriptAction :
             .setTitle("Shopware: Select App")
             .setItemChosenCallback(Runnable {
                 CommandProcessor.getInstance().executeCommand(project, {
-                    this.createFile(jbAppList.selectedValue, scriptHook, project)
+                    this.createFile(jbAppList.selectedValue, scriptHook, project, startedAt)
 
                 }, "Create Hook", null)
             })
@@ -97,7 +100,7 @@ class NewAppScriptAction :
             .showInFocusCenter()
     }
 
-    private fun createFile(app: ShopwareApp, scriptHook: ScriptHook, project: Project) {
+    private fun createFile(app: ShopwareApp, scriptHook: ScriptHook, project: Project, startedAt: Long) {
         val localFolder = LocalFileSystem.getInstance().findFileByPath(app.rootFolder)
         val psiDir = PsiManager.getInstance(project).findDirectory(localFolder!!) as PsiDirectory
 
@@ -118,5 +121,7 @@ class NewAppScriptAction :
             ),
             scriptsDir
         ) ?: return
+
+        TelemetryClient.trackFeature(project, "generator.app_script", startedAt)
     }
 }

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/cms/NewCmsBlockAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/cms/NewCmsBlockAction.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.psi.PsiManager
 import com.jetbrains.twig.TwigFileType
 import de.shyim.shopware6.action.generator.ActionUtil
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.templates.ShopwareTemplates
 import de.shyim.shopware6.util.PsiUtil
 import de.shyim.shopware6.util.ShopwareBundleUtil
@@ -22,6 +23,8 @@ class NewCmsBlockAction :
         if (e.project == null) {
             return
         }
+
+        val startedAt = System.currentTimeMillis()
 
         val ui = NewCmsBlockDialogWrapper(ShopwareBundleUtil.getAllBundles(e.project!!))
         val result = ui.showAndGetResult() ?: return
@@ -124,6 +127,8 @@ class NewCmsBlockAction :
             ),
             storefrontFolder
         ) ?: return
+
+        TelemetryClient.trackFeature(e.project, "generator.cms_block", startedAt)
 
         val view = LangDataKeys.IDE_VIEW.getData(e.dataContext) ?: return
 

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/cms/NewCmsElementAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/cms/NewCmsElementAction.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.psi.PsiManager
 import com.jetbrains.twig.TwigFileType
 import de.shyim.shopware6.action.generator.ActionUtil
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.templates.ShopwareTemplates
 import de.shyim.shopware6.util.PsiUtil
 import de.shyim.shopware6.util.ShopwareBundleUtil
@@ -26,6 +27,8 @@ class NewCmsElementAction :
         if (e.project == null) {
             return
         }
+
+        val startedAt = System.currentTimeMillis()
 
         val ui = NewCmsElementDialogWrapper(ShopwareBundleUtil.getAllBundles(e.project!!))
         val result = ui.showAndGetResult() ?: return
@@ -178,6 +181,8 @@ class NewCmsElementAction :
             ),
             storefrontFolder
         ) ?: return
+
+        TelemetryClient.trackFeature(e.project, "generator.cms_element", startedAt)
 
         val view = LangDataKeys.IDE_VIEW.getData(e.dataContext) ?: return
 

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/php/NewMigrationAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/php/NewMigrationAction.kt
@@ -5,12 +5,15 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.jetbrains.php.lang.PhpFileType
 import com.jetbrains.php.roots.PhpNamespaceCompositeProvider
 import de.shyim.shopware6.action.generator.ActionUtil
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.templates.ShopwareTemplates
 import icons.ShopwareToolBoxIcons
 
 class NewMigrationAction :
     DumbAwareAction("Create a Migration", "Create a new Migration", ShopwareToolBoxIcons.SHOPWARE) {
     override fun actionPerformed(e: AnActionEvent) {
+        val startedAt = System.currentTimeMillis()
+
         val directory = ActionUtil.getViewDirectory(e.dataContext) ?: return
 
         val namespaces = PhpNamespaceCompositeProvider.INSTANCE.suggestNamespaces(directory)
@@ -26,5 +29,7 @@ class NewMigrationAction :
             config.fileName(),
             PhpFileType.INSTANCE
         )
+
+        TelemetryClient.trackFeature(e.project, "generator.migration", startedAt)
     }
 }

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/php/NewPluginAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/php/NewPluginAction.kt
@@ -13,7 +13,6 @@ import com.jetbrains.php.lang.PhpFileType
 import de.shyim.shopware6.action.generator.ActionUtil
 import de.shyim.shopware6.templates.ShopwareTemplates
 import de.shyim.shopware6.telemetry.TelemetryClient
-import de.shyim.shopware6.telemetry.TelemetryConsent
 import icons.ShopwareToolBoxIcons
 
 class NewPluginAction : DumbAwareAction("Create a Plugin", "Create a new Plugin", ShopwareToolBoxIcons.SHOPWARE) {
@@ -108,13 +107,7 @@ class NewPluginAction : DumbAwareAction("Create a Plugin", "Create a new Plugin"
             configFolder
         )
 
-        if (TelemetryConsent.requestIfNeeded(e.project)) {
-            TelemetryClient.getInstance().track(
-                feature = "generator.plugin",
-                result = "success",
-                durationMs = System.currentTimeMillis() - startedAt,
-            )
-        }
+        TelemetryClient.trackFeature(e.project, "generator.plugin", startedAt)
 
         val view = LangDataKeys.IDE_VIEW.getData(e.dataContext) ?: return
         view.selectElement(pluginBootstrapFile!!)
@@ -136,4 +129,3 @@ class NewPluginAction : DumbAwareAction("Create a Plugin", "Create a new Plugin"
         )
     }
 }
-

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/php/NewPluginAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/php/NewPluginAction.kt
@@ -12,10 +12,14 @@ import com.intellij.psi.PsiDirectory
 import com.jetbrains.php.lang.PhpFileType
 import de.shyim.shopware6.action.generator.ActionUtil
 import de.shyim.shopware6.templates.ShopwareTemplates
+import de.shyim.shopware6.telemetry.TelemetryClient
+import de.shyim.shopware6.telemetry.TelemetryConsent
 import icons.ShopwareToolBoxIcons
 
 class NewPluginAction : DumbAwareAction("Create a Plugin", "Create a new Plugin", ShopwareToolBoxIcons.SHOPWARE) {
     override fun actionPerformed(e: AnActionEvent) {
+        val startedAt = System.currentTimeMillis()
+
         val wrapper = NewPluginDialogWrapper()
         val config = wrapper.showAndGetConfig() ?: return
 
@@ -104,6 +108,14 @@ class NewPluginAction : DumbAwareAction("Create a Plugin", "Create a new Plugin"
             configFolder
         )
 
+        if (TelemetryConsent.requestIfNeeded(e.project)) {
+            TelemetryClient.getInstance().track(
+                feature = "generator.plugin",
+                result = "success",
+                durationMs = System.currentTimeMillis() - startedAt,
+            )
+        }
+
         val view = LangDataKeys.IDE_VIEW.getData(e.dataContext) ?: return
         view.selectElement(pluginBootstrapFile!!)
     }
@@ -124,3 +136,4 @@ class NewPluginAction : DumbAwareAction("Create a Plugin", "Create a new Plugin"
         )
     }
 }
+

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/php/NewScheduledTaskAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/php/NewScheduledTaskAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.jetbrains.php.lang.PhpFileType
 import com.jetbrains.php.roots.PhpNamespaceCompositeProvider
 import de.shyim.shopware6.action.generator.ActionUtil
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.templates.ShopwareTemplates
 import de.shyim.shopware6.templates.ShopwareTemplates.Companion.SHOPWARE_PHP_SCHEDULED_TASK
 import de.shyim.shopware6.templates.ShopwareTemplates.Companion.SHOPWARE_PHP_SCHEDULED_TASK_HANDLER
@@ -13,6 +14,8 @@ import icons.ShopwareToolBoxIcons
 class NewScheduledTaskAction :
     DumbAwareAction("Create Scheduled Task", "Create a new ScheduledTask ", ShopwareToolBoxIcons.SHOPWARE) {
     override fun actionPerformed(e: AnActionEvent) {
+        val startedAt = System.currentTimeMillis()
+
         val directory = ActionUtil.getViewDirectory(e.dataContext) ?: return
 
         val namespaces = PhpNamespaceCompositeProvider.INSTANCE.suggestNamespaces(directory)
@@ -36,5 +39,7 @@ class NewScheduledTaskAction :
             config.name + "TaskHandler.php",
             PhpFileType.INSTANCE
         )
+
+        TelemetryClient.trackFeature(e.project, "generator.scheduled_task", startedAt)
     }
 }

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/vue/NewComponentAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/vue/NewComponentAction.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.ui.Messages
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiFileFactory
 import de.shyim.shopware6.action.generator.ActionUtil
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.templates.ShopwareTemplates
 
 class NewComponentAction :
@@ -21,6 +22,8 @@ class NewComponentAction :
             return
         }
 
+        val startedAt = System.currentTimeMillis()
+
         val dialog = NewComponentDialogWrapper()
         val config = dialog.showAndGetName() ?: return
 
@@ -29,6 +32,8 @@ class NewComponentAction :
         val folder = ActionUtil.getViewDirectory(e.dataContext) ?: return
 
         val componentFolder = createComponent(e.project!!, folder, config)
+
+        TelemetryClient.trackFeature(e.project, "generator.admin_component", startedAt)
 
         val view = LangDataKeys.IDE_VIEW.getData(e.dataContext) ?: return
         val psiFile = componentFolder!!.findFile("index.js")

--- a/src/main/kotlin/de/shyim/shopware6/action/generator/vue/NewModuleAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/generator/vue/NewModuleAction.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.codeStyle.CodeStyleManager
 import de.shyim.shopware6.action.generator.ActionUtil
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.templates.ShopwareTemplates
 
 class NewModuleAction :
@@ -20,6 +21,8 @@ class NewModuleAction :
         if (e.project == null) {
             return
         }
+
+        val startedAt = System.currentTimeMillis()
 
         val ui = NewModuleDialogWrapper()
         val config = ui.showAndGetConfig() ?: return
@@ -71,6 +74,8 @@ class NewModuleAction :
 
         createSnippet(project, snippetFolder, config.name, "de-DE")
         createSnippet(project, snippetFolder, config.name, "en-GB")
+
+        TelemetryClient.trackFeature(project, "generator.admin_module", startedAt)
 
         val view = LangDataKeys.IDE_VIEW.getData(e.dataContext) ?: return
         val psiFile = moduleFolder.findFile("index.js")

--- a/src/main/kotlin/de/shyim/shopware6/action/project/ConfigureShopwareProjectAction.kt
+++ b/src/main/kotlin/de/shyim/shopware6/action/project/ConfigureShopwareProjectAction.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ContentEntry
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.vfs.LocalFileSystem
+import de.shyim.shopware6.telemetry.TelemetryClient
 import de.shyim.shopware6.util.ShopwareBundleUtil
 import icons.ShopwareToolBoxIcons
 import org.apache.commons.io.FileUtils
@@ -27,6 +28,8 @@ class ConfigureShopwareProjectAction : DumbAwareAction(
         if (e.project == null) {
             return
         }
+
+        val startedAt = System.currentTimeMillis()
 
         val model = ModuleRootManager.getInstance(ModuleManager.getInstance(e.project!!).modules[0]).modifiableModel
         val basePath = e.project!!.basePath + "/src"
@@ -81,6 +84,7 @@ class ConfigureShopwareProjectAction : DumbAwareAction(
             ), e.project
         )
 
+        TelemetryClient.trackFeature(e.project, "project.configure", startedAt)
     }
 
     private fun addShopwareExcludes(model: ContentEntry) {

--- a/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetryClient.kt
+++ b/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetryClient.kt
@@ -1,0 +1,97 @@
+package de.shyim.shopware6.telemetry
+
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.util.SystemInfo
+import org.codehaus.jettison.json.JSONObject
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+
+@Service(Service.Level.APP)
+class TelemetryClient {
+    fun track(
+        feature: String,
+        result: String,
+        durationMs: Long,
+    ) {
+        val settings = TelemetrySettings.getInstance()
+
+        if (settings.consent != TelemetrySettings.CONSENT_ENABLED) {
+            return
+        }
+
+        if (System.getenv().containsKey("DO_NOT_TRACK")) {
+            return
+        }
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            runCatching {
+                sendEvent(feature, result, durationMs, settings.installationId)
+            }
+        }
+    }
+
+    private fun sendEvent(
+        feature: String,
+        result: String,
+        durationMs: Long,
+        installationId: String,
+    ) {
+        val tags = JSONObject().apply {
+            put("feature", feature)
+            put("result", result)
+            put("plugin_version", pluginVersion())
+            put("ide_version", ApplicationInfo.getInstance().fullVersion)
+            put("os", operatingSystem())
+            put("duration_ms", durationMs.toString())
+        }
+
+        val payload = JSONObject().apply {
+            put("event", EVENT_NAME)
+            put("user_id", installationId)
+            put("timestamp", Instant.now().toString())
+            put("tags", tags)
+        }
+
+        val bytes = payload.toString().toByteArray(StandardCharsets.UTF_8)
+        val domain = System.getenv("SHOPWARE_TRACKING_DOMAIN")
+            ?.takeIf { it.isNotBlank() }
+            ?: DEFAULT_DOMAIN
+
+        DatagramSocket().use { socket ->
+            val address = InetAddress.getByName(domain)
+            val packet = DatagramPacket(bytes, bytes.size, address, DEFAULT_PORT)
+            socket.send(packet)
+        }
+    }
+
+    private fun pluginVersion(): String =
+        PluginManagerCore
+            .getPlugin(PluginId.getId(PLUGIN_ID))
+            ?.version
+            ?: "unknown"
+
+    private fun operatingSystem(): String =
+        when {
+            SystemInfo.isMac -> "macos"
+            SystemInfo.isWindows -> "windows"
+            SystemInfo.isLinux -> "linux"
+            else -> "other"
+        }
+
+    companion object {
+        private const val EVENT_NAME = "shopware_phpstorm.feature_used"
+        private const val PLUGIN_ID = "de.shyim.shopware6"
+        private const val DEFAULT_DOMAIN = "udp.usage.shopware.io"
+        private const val DEFAULT_PORT = 9000
+
+        fun getInstance(): TelemetryClient =
+            ApplicationManager.getApplication().getService(TelemetryClient::class.java)
+    }
+}

--- a/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetryClient.kt
+++ b/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetryClient.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import org.codehaus.jettison.json.JSONObject
 import java.net.DatagramPacket
@@ -93,5 +94,15 @@ class TelemetryClient {
 
         fun getInstance(): TelemetryClient =
             ApplicationManager.getApplication().getService(TelemetryClient::class.java)
+
+        fun trackFeature(project: Project?, feature: String, startedAt: Long) {
+            if (TelemetryConsent.requestIfNeeded(project)) {
+                getInstance().track(
+                    feature = feature,
+                    result = "success",
+                    durationMs = System.currentTimeMillis() - startedAt,
+                )
+            }
+        }
     }
 }

--- a/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetryClient.kt
+++ b/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetryClient.kt
@@ -1,10 +1,9 @@
 package de.shyim.shopware6.telemetry
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.cl.PluginAwareClassLoader
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import org.codehaus.jettison.json.JSONObject
@@ -73,8 +72,8 @@ class TelemetryClient {
     }
 
     private fun pluginVersion(): String =
-        PluginManagerCore
-            .getPlugin(PluginId.getId(PLUGIN_ID))
+        (TelemetryClient::class.java.classLoader as? PluginAwareClassLoader)
+            ?.pluginDescriptor
             ?.version
             ?: "unknown"
 
@@ -88,7 +87,6 @@ class TelemetryClient {
 
     companion object {
         private const val EVENT_NAME = "shopware_phpstorm.feature_used"
-        private const val PLUGIN_ID = "de.shyim.shopware6"
         private const val DEFAULT_DOMAIN = "udp.usage.shopware.io"
         private const val DEFAULT_PORT = 9000
 

--- a/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetryConfigurable.kt
+++ b/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetryConfigurable.kt
@@ -1,0 +1,53 @@
+package de.shyim.shopware6.telemetry
+
+import com.intellij.openapi.options.Configurable
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.util.ui.FormBuilder
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class TelemetryConfigurable : Configurable {
+    private var telemetryCheckbox: JBCheckBox? = null
+    private var panel: JPanel? = null
+
+    override fun getDisplayName(): String = "Shopware 6 Toolbox"
+
+    override fun createComponent(): JComponent {
+        telemetryCheckbox = JBCheckBox("Send anonymous usage statistics")
+
+        panel = FormBuilder.createFormBuilder()
+            .addComponent(telemetryCheckbox!!)
+            .addComponentFillVertically(JPanel(), 0)
+            .panel
+
+        reset()
+
+        return panel!!
+    }
+
+    override fun isModified(): Boolean {
+        val telemetryEnabled =
+            TelemetrySettings.getInstance().consent == TelemetrySettings.CONSENT_ENABLED
+
+        return telemetryCheckbox?.isSelected != telemetryEnabled
+    }
+
+    override fun apply() {
+        TelemetrySettings.getInstance().consent =
+            if (telemetryCheckbox?.isSelected == true) {
+                TelemetrySettings.CONSENT_ENABLED
+            } else {
+                TelemetrySettings.CONSENT_DISABLED
+            }
+    }
+
+    override fun reset() {
+        telemetryCheckbox?.isSelected =
+            TelemetrySettings.getInstance().consent == TelemetrySettings.CONSENT_ENABLED
+    }
+
+    override fun disposeUIResources() {
+        telemetryCheckbox = null
+        panel = null
+    }
+}

--- a/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetryConsent.kt
+++ b/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetryConsent.kt
@@ -1,0 +1,37 @@
+package de.shyim.shopware6.telemetry
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+
+object TelemetryConsent {
+    fun requestIfNeeded(project: Project?): Boolean {
+        val settings = TelemetrySettings.getInstance()
+
+        when (settings.consent) {
+            TelemetrySettings.CONSENT_ENABLED -> return true
+            TelemetrySettings.CONSENT_DISABLED -> return false
+        }
+
+        val answer = Messages.showYesNoDialog(
+            project,
+            """
+            Help improve Shopware 6 Toolbox by sending anonymous feature-usage statistics.
+
+            We do not collect source code, file names, project names, or personal information.
+            """.trimIndent(),
+            "Anonymous Usage Statistics",
+            "Allow",
+            "No Thanks",
+            Messages.getQuestionIcon(),
+        )
+
+        settings.consent =
+            if (answer == Messages.YES) {
+                TelemetrySettings.CONSENT_ENABLED
+            } else {
+                TelemetrySettings.CONSENT_DISABLED
+            }
+
+        return answer == Messages.YES
+    }
+}

--- a/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetryConsent.kt
+++ b/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetryConsent.kt
@@ -1,9 +1,14 @@
 package de.shyim.shopware6.telemetry
 
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.ui.Messages
+import java.util.concurrent.atomic.AtomicBoolean
 
 object TelemetryConsent {
+    private val consentRequested = AtomicBoolean(false)
+
     fun requestIfNeeded(project: Project?): Boolean {
         val settings = TelemetrySettings.getInstance()
 
@@ -12,26 +17,32 @@ object TelemetryConsent {
             TelemetrySettings.CONSENT_DISABLED -> return false
         }
 
-        val answer = Messages.showYesNoDialog(
-            project,
-            """
-            Help improve Shopware 6 Toolbox by sending anonymous feature-usage statistics.
+        if (consentRequested.compareAndSet(false, true)) {
+            showConsentNotification(project)
+        }
 
-            We do not collect source code, file names, project names, or personal information.
-            """.trimIndent(),
-            "Anonymous Usage Statistics",
-            "Allow",
-            "No Thanks",
-            Messages.getQuestionIcon(),
-        )
+        return false
+    }
 
-        settings.consent =
-            if (answer == Messages.YES) {
-                TelemetrySettings.CONSENT_ENABLED
-            } else {
-                TelemetrySettings.CONSENT_DISABLED
-            }
+    private fun showConsentNotification(project: Project?) {
+        val notification = NotificationGroupManager.getInstance()
+            .getNotificationGroup("Shopware Telemetry")
+            .createNotification(
+                "Anonymous usage statistics",
+                "Help improve Shopware 6 Toolbox by sending anonymous feature-usage statistics. " +
+                    "We do not collect source code, file names, project names, or personal information. " +
+                    "You can change this anytime in Settings | Tools | Shopware 6 Toolbox.",
+                NotificationType.INFORMATION,
+            )
 
-        return answer == Messages.YES
+        notification.addAction(NotificationAction.createSimpleExpiring("Allow") {
+            TelemetrySettings.getInstance().consent = TelemetrySettings.CONSENT_ENABLED
+        })
+
+        notification.addAction(NotificationAction.createSimpleExpiring("No thanks") {
+            TelemetrySettings.getInstance().consent = TelemetrySettings.CONSENT_DISABLED
+        })
+
+        notification.notify(project)
     }
 }

--- a/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetrySettings.kt
+++ b/src/main/kotlin/de/shyim/shopware6/telemetry/TelemetrySettings.kt
@@ -1,0 +1,52 @@
+package de.shyim.shopware6.telemetry
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.RoamingType
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import java.util.UUID
+
+@Service(Service.Level.APP)
+@State(
+    name = "ShopwareToolboxTelemetry",
+    storages = [
+        Storage(
+            value = "shopware6-toolbox-telemetry.xml",
+            roamingType = RoamingType.DISABLED,
+        ),
+    ],
+)
+class TelemetrySettings : PersistentStateComponent<TelemetrySettings.SettingsState> {
+    data class SettingsState(
+        var consent: String = CONSENT_UNKNOWN,
+        var installationId: String = UUID.randomUUID().toString(),
+    )
+
+    private var settingsState = SettingsState()
+
+    override fun getState(): SettingsState = settingsState
+
+    override fun loadState(state: SettingsState) {
+        settingsState = state
+    }
+
+    var consent: String
+        get() = settingsState.consent
+        set(value) {
+            settingsState.consent = value
+        }
+
+    val installationId: String
+        get() = settingsState.installationId
+
+    companion object {
+        const val CONSENT_UNKNOWN = "unknown"
+        const val CONSENT_ENABLED = "enabled"
+        const val CONSENT_DISABLED = "disabled"
+
+        fun getInstance(): TelemetrySettings =
+            ApplicationManager.getApplication().getService(TelemetrySettings::class.java)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -254,6 +254,9 @@
         <notificationGroup id="Shopware"
                            displayType="BALLOON"
                            key="notification.group.name"/>
+
+        <notificationGroup id="Shopware Telemetry"
+                           displayType="STICKY_BALLOON"/>
     </extensions>
 
     <actions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,12 @@
     <depends optional="true" config-file="de.shyim.shopware6.symfony.xml">fr.adrienbrault.idea.symfony2plugin</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+        <applicationConfigurable
+                id="de.shyim.shopware6.telemetry"
+                parentId="tools"
+                displayName="Shopware 6 Toolbox"
+                instance="de.shyim.shopware6.telemetry.TelemetryConfigurable"/>
+
         <defaultLiveTemplates file="/liveTemplates/Shopware 6 Config_xml.xml"/>
         <defaultLiveTemplates file="/liveTemplates/Shopware 6 PHP.xml"/>
         <defaultLiveTemplates file="/liveTemplates/Shopware 6 General.xml"/>


### PR DESCRIPTION
## What

Adds opt-in anonymous usage telemetry for the Shopware 6 Toolbox plugin.

Initially tracks successful use of the plugin generator.

## Privacy controls

- Explicit consent prompt
- Settings checkbox to enable or disable telemetry
- Supports the DO_NOT_TRACK environment variable
- Does not collect source code, file names, or project names

## Testing

- compileKotlin passes
- Local UDP event delivery confirmed

Plugin Verifier reports compatibility with both tested IDE versions, but fails on the existing PluginManagerCore internal API usage in TelemetryClient.pluginVersion(). I have not changed that implementation.