### PR TITLE
Add inspection for Twig blocks removed from upstream Shopware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+- Added new inspection that warns when a Twig block with a versioning comment has been removed from the upstream Shopware template
+
 ## 0.0.55 - 2026-07-10
 
 - Marked as compatible with next major version of Jetbrains IDEs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 
 - Added new inspection that warns when a Twig block with a versioning comment has been removed from the upstream Shopware template
+- Fixed "block does not have a versioning comment" inspection being reported on the Shopware core templates themselves
 
 ## 0.0.55 - 2026-07-10
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ platformDownloadSources=true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins=com.jetbrains.php:261.26222.22,com.jetbrains.twig:261.22158.185,fr.adrienbrault.idea.symfony2plugin:2026.1.308,de.espend.idea.php.annotation:12.1.0
+platformPlugins=com.jetbrains.php:261.22158.208,com.jetbrains.twig:261.22158.185,fr.adrienbrault.idea.symfony2plugin:2026.1.308,de.espend.idea.php.annotation:12.1.0
 
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins = JavaScript,org.jetbrains.plugins.yaml,org.jetbrains.plugins.sass

--- a/src/main/kotlin/de/shyim/shopware6/index/TwigBlockHashIndex.kt
+++ b/src/main/kotlin/de/shyim/shopware6/index/TwigBlockHashIndex.kt
@@ -22,10 +22,7 @@ class TwigBlockHashIndex : FileBasedIndexExtension<String, TwigBlockHash>() {
         return DataIndexer { inputData ->
             val hashes = HashMap<String, TwigBlockHash>()
 
-            if (!inputData.file.path.contains("src/Storefront/Resources/views/storefront") && !inputData.file.path.contains(
-                    "vendor/shopware/storefront/Resources/views/storefront"
-                )
-            ) {
+            if (!TwigUtil.isShopwareCoreTemplate(inputData.file.path)) {
                 return@DataIndexer mapOf()
             }
 

--- a/src/main/kotlin/de/shyim/shopware6/inspection/twig/TwigBlockHashMissing.kt
+++ b/src/main/kotlin/de/shyim/shopware6/inspection/twig/TwigBlockHashMissing.kt
@@ -14,6 +14,12 @@ import de.shyim.shopware6.util.TwigUtil
 
 class TwigBlockHashMissing : LocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        // the Shopware core templates itself don't need a versioning comment
+        val virtualFile = holder.file.originalFile.virtualFile
+        if (virtualFile != null && TwigUtil.isShopwareCoreTemplate(virtualFile.path)) {
+            return super.buildVisitor(holder, isOnTheFly)
+        }
+
         return object : PsiElementVisitor() {
             override fun visitElement(element: PsiElement) {
                 if (element is TwigBlockTag && element.name !== null && TwigUtil.getShopwareBlockComment(element) === null) {

--- a/src/main/kotlin/de/shyim/shopware6/inspection/twig/TwigBlockRemoved.kt
+++ b/src/main/kotlin/de/shyim/shopware6/inspection/twig/TwigBlockRemoved.kt
@@ -1,0 +1,60 @@
+package de.shyim.shopware6.inspection.twig
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.util.indexing.FileBasedIndex
+import com.jetbrains.twig.TwigFile
+import com.jetbrains.twig.elements.TwigBlockTag
+import de.shyim.shopware6.index.TwigBlockHashIndex
+import de.shyim.shopware6.util.TwigUtil
+
+class TwigBlockRemoved : LocalInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        val file = holder.file
+
+        if (file !is TwigFile) {
+            return super.buildVisitor(holder, isOnTheFly)
+        }
+
+        return object : PsiElementVisitor() {
+            override fun visitElement(element: PsiElement) {
+                if (element is TwigBlockTag && element.name !== null && TwigUtil.getShopwareBlockComment(element) !== null) {
+                    val upstreamBlocks = FileBasedIndex.getInstance().getValues(
+                        TwigBlockHashIndex.key,
+                        element.name!!,
+                        GlobalSearchScope.allScope(element.project)
+                    )
+
+                    if (upstreamBlocks.any { it.relativePath == TwigUtil.getRelativePath(element.containingFile.originalFile.virtualFile.path) }) {
+                        return
+                    }
+
+                    // without any indexed upstream templates every block would be reported as removed
+                    if (FileBasedIndex.getInstance().getAllKeys(TwigBlockHashIndex.key, element.project).isEmpty()) {
+                        return
+                    }
+
+                    if (upstreamBlocks.isEmpty()) {
+                        holder.registerProblem(
+                            element.parent,
+                            "The upstream block has been removed, please check if your override is still needed",
+                            ProblemHighlightType.WARNING
+                        )
+                    } else {
+                        holder.registerProblem(
+                            element.parent,
+                            "The upstream block has been removed from this template, but still exists in: ${
+                                upstreamBlocks.joinToString(", ") { it.relativePath }
+                            }",
+                            ProblemHighlightType.WARNING
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/de/shyim/shopware6/util/TwigUtil.kt
+++ b/src/main/kotlin/de/shyim/shopware6/util/TwigUtil.kt
@@ -47,6 +47,10 @@ object TwigUtil {
         return path.substringAfter("Resources/views/")
     }
 
+    fun isShopwareCoreTemplate(path: String): Boolean {
+        return path.contains("src/Storefront/Resources/views/storefront") || path.contains("vendor/shopware/storefront/Resources/views/storefront")
+    }
+
     fun getShopwareBlockComment(element: PsiElement?): PsiElement? {
         if (element == null) {
             return null

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -212,6 +212,17 @@
                 language="Twig"
         />
 
+        <localInspection
+                groupPath="Shopware 6"
+                shortName="Shopware6TwigBlockRemoved"
+                displayName="The upstream block has been removed. Please check that your override is still needed"
+                groupName="Twig"
+                enabledByDefault="true"
+                level="WARNING"
+                implementationClass="de.shyim.shopware6.inspection.twig.TwigBlockRemoved"
+                language="Twig"
+        />
+
         <intentionAction>
             <className>de.shyim.shopware6.intentions.ExtendTwigBlockIntention</className>
             <category>Shopware</category>

--- a/src/main/resources/inspectionDescriptions/Shopware6TwigBlockRemoved.html
+++ b/src/main/resources/inspectionDescriptions/Shopware6TwigBlockRemoved.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        Shows a warning on Twig blocks with a versioning comment, when the block does not exist anymore in the upstream Shopware template.
+    </body>
+</html>

--- a/src/test/kotlin/de/shyim/shopware6/test/index/TwigBlockDeprecationIndexTest.kt
+++ b/src/test/kotlin/de/shyim/shopware6/test/index/TwigBlockDeprecationIndexTest.kt
@@ -16,7 +16,14 @@ class TwigBlockDeprecationIndexTest : BasePlatformTestCase() {
     }
 
     fun testDeprecationFound() {
+        // getAllKeys can contain stale keys from other tests sharing the index storage,
+        // so only count keys with values in this project
         val keys = FileBasedIndex.getInstance().getAllKeys(TwigBlockDeprecationIndex.key, project)
+            .filter {
+                FileBasedIndex.getInstance()
+                    .getValues(TwigBlockDeprecationIndex.key, it, GlobalSearchScope.allScope(project))
+                    .isNotEmpty()
+            }
         assertSame(1, keys.size)
         assertEquals("component_line_item_type_product_order_number", keys.first())
 

--- a/src/test/kotlin/de/shyim/shopware6/test/inspection/TwigBlockDeprecatedTest.kt
+++ b/src/test/kotlin/de/shyim/shopware6/test/inspection/TwigBlockDeprecatedTest.kt
@@ -1,0 +1,19 @@
+package de.shyim.shopware6.test.inspection
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import de.shyim.shopware6.inspection.twig.TwigBlockDeprecated
+
+class TwigBlockDeprecatedTest : BasePlatformTestCase() {
+    override fun getTestDataPath(): String {
+        return "src/test/testData/inspection/TwigBlockDeprecatedTest/"
+    }
+
+    fun testDeprecatedBlocksAreReported() {
+        myFixture.copyDirectoryToProject("ShopwarePlatform", "ShopwarePlatform")
+        myFixture.copyDirectoryToProject("MyPlugin", "MyPlugin")
+        myFixture.enableInspections(TwigBlockDeprecated())
+
+        myFixture.configureFromTempProjectFile("MyPlugin/Resources/views/storefront/page/index.html.twig")
+        myFixture.checkHighlighting(true, false, true)
+    }
+}

--- a/src/test/kotlin/de/shyim/shopware6/test/inspection/TwigBlockHashChangedTest.kt
+++ b/src/test/kotlin/de/shyim/shopware6/test/inspection/TwigBlockHashChangedTest.kt
@@ -1,0 +1,42 @@
+package de.shyim.shopware6.test.inspection
+
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.util.indexing.FileBasedIndex
+import de.shyim.shopware6.index.TwigBlockHashIndex
+import de.shyim.shopware6.inspection.twig.TwigBlockHashChanged
+
+class TwigBlockHashChangedTest : BasePlatformTestCase() {
+    override fun getTestDataPath(): String {
+        return "src/test/testData/inspection/TwigBlockHashChangedTest/"
+    }
+
+    fun testChangedUpstreamBlockIsReported() {
+        myFixture.copyDirectoryToProject("ShopwarePlatform", "ShopwarePlatform")
+        myFixture.enableInspections(TwigBlockHashChanged())
+
+        val currentHash = FileBasedIndex.getInstance().getValues(
+            TwigBlockHashIndex.key,
+            "base_content",
+            GlobalSearchScope.allScope(project)
+        ).first().hash
+
+        val file = myFixture.addFileToProject(
+            "MyPlugin/Resources/views/storefront/page/content/index.html.twig",
+            """
+            {# shopware-block: $currentHash@6.6.0.0 #}
+            {% block base_content %}
+                <div>override of unchanged upstream block</div>
+            {% endblock %}
+
+            {# shopware-block: outdatedhash@6.5.0.0 #}
+            <warning descr="The upstream block has been changed, please update the block">{% block base_other %}
+                <div>override of changed upstream block</div>
+            {% endblock %}</warning>
+            """.trimIndent()
+        )
+
+        myFixture.configureFromExistingVirtualFile(file.virtualFile)
+        myFixture.checkHighlighting(true, false, true)
+    }
+}

--- a/src/test/kotlin/de/shyim/shopware6/test/inspection/TwigBlockHashMissingTest.kt
+++ b/src/test/kotlin/de/shyim/shopware6/test/inspection/TwigBlockHashMissingTest.kt
@@ -1,0 +1,19 @@
+package de.shyim.shopware6.test.inspection
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import de.shyim.shopware6.inspection.twig.TwigBlockHashMissing
+
+class TwigBlockHashMissingTest : BasePlatformTestCase() {
+    override fun getTestDataPath(): String {
+        return "src/test/testData/inspection/TwigBlockHashMissingTest/"
+    }
+
+    fun testBlocksWithoutVersioningCommentAreReported() {
+        myFixture.copyDirectoryToProject("ShopwarePlatform", "ShopwarePlatform")
+        myFixture.copyDirectoryToProject("MyPlugin", "MyPlugin")
+        myFixture.enableInspections(TwigBlockHashMissing())
+
+        myFixture.configureFromTempProjectFile("MyPlugin/Resources/views/storefront/page/content/index.html.twig")
+        myFixture.checkHighlighting(true, false, true)
+    }
+}

--- a/src/test/kotlin/de/shyim/shopware6/test/inspection/TwigBlockHashMissingTest.kt
+++ b/src/test/kotlin/de/shyim/shopware6/test/inspection/TwigBlockHashMissingTest.kt
@@ -16,4 +16,12 @@ class TwigBlockHashMissingTest : BasePlatformTestCase() {
         myFixture.configureFromTempProjectFile("MyPlugin/Resources/views/storefront/page/content/index.html.twig")
         myFixture.checkHighlighting(true, false, true)
     }
+
+    fun testShopwareCoreTemplatesAreNotReported() {
+        myFixture.copyDirectoryToProject("ShopwarePlatform", "ShopwarePlatform")
+        myFixture.enableInspections(TwigBlockHashMissing())
+
+        myFixture.configureFromTempProjectFile("ShopwarePlatform/src/Storefront/Resources/views/storefront/page/content/index.html.twig")
+        myFixture.checkHighlighting(true, false, true)
+    }
 }

--- a/src/test/kotlin/de/shyim/shopware6/test/inspection/TwigBlockRemovedTest.kt
+++ b/src/test/kotlin/de/shyim/shopware6/test/inspection/TwigBlockRemovedTest.kt
@@ -1,0 +1,19 @@
+package de.shyim.shopware6.test.inspection
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import de.shyim.shopware6.inspection.twig.TwigBlockRemoved
+
+class TwigBlockRemovedTest : BasePlatformTestCase() {
+    override fun getTestDataPath(): String {
+        return "src/test/testData/inspection/TwigBlockRemovedTest/"
+    }
+
+    fun testRemovedBlocksAreReported() {
+        myFixture.copyDirectoryToProject("ShopwarePlatform", "ShopwarePlatform")
+        myFixture.copyDirectoryToProject("MyPlugin", "MyPlugin")
+        myFixture.enableInspections(TwigBlockRemoved())
+
+        myFixture.configureFromTempProjectFile("MyPlugin/Resources/views/storefront/page/content/index.html.twig")
+        myFixture.checkHighlighting(true, false, true)
+    }
+}

--- a/src/test/testData/inspection/TwigBlockDeprecatedTest/MyPlugin/Resources/views/storefront/page/index.html.twig
+++ b/src/test/testData/inspection/TwigBlockDeprecatedTest/MyPlugin/Resources/views/storefront/page/index.html.twig
@@ -1,0 +1,7 @@
+<warning descr="This block is deprecated: Block will be removed. Use `new_block` instead.">{% block old_block %}</warning>
+    <div>override</div>
+{% endblock %}
+
+{% block fine_block %}
+    <div>override</div>
+{% endblock %}

--- a/src/test/testData/inspection/TwigBlockDeprecatedTest/ShopwarePlatform/src/Storefront/Resources/views/storefront/page/index.html.twig
+++ b/src/test/testData/inspection/TwigBlockDeprecatedTest/ShopwarePlatform/src/Storefront/Resources/views/storefront/page/index.html.twig
@@ -1,0 +1,8 @@
+{# @deprecated tag:v6.7.0 - Block will be removed. Use `new_block` instead. #}
+{% block old_block %}
+    <div>old</div>
+{% endblock %}
+
+{% block fine_block %}
+    <div>fine</div>
+{% endblock %}

--- a/src/test/testData/inspection/TwigBlockHashChangedTest/ShopwarePlatform/src/Storefront/Resources/views/storefront/page/content/index.html.twig
+++ b/src/test/testData/inspection/TwigBlockHashChangedTest/ShopwarePlatform/src/Storefront/Resources/views/storefront/page/content/index.html.twig
@@ -1,0 +1,7 @@
+{% block base_content %}
+    <div>content</div>
+{% endblock %}
+
+{% block base_other %}
+    <div>other</div>
+{% endblock %}

--- a/src/test/testData/inspection/TwigBlockHashMissingTest/MyPlugin/Resources/views/storefront/page/content/index.html.twig
+++ b/src/test/testData/inspection/TwigBlockHashMissingTest/MyPlugin/Resources/views/storefront/page/content/index.html.twig
@@ -1,0 +1,12 @@
+<warning descr="The block does not have a versioning comment">{% block base_content %}
+    <div>override without comment</div>
+{% endblock %}</warning>
+
+{# shopware-block: somehash@6.6.0.0 #}
+{% block base_footer %}
+    <div>override with comment</div>
+{% endblock %}
+
+{% block custom_plugin_block %}
+    <div>own block, not upstream</div>
+{% endblock %}

--- a/src/test/testData/inspection/TwigBlockHashMissingTest/ShopwarePlatform/src/Storefront/Resources/views/storefront/page/content/index.html.twig
+++ b/src/test/testData/inspection/TwigBlockHashMissingTest/ShopwarePlatform/src/Storefront/Resources/views/storefront/page/content/index.html.twig
@@ -1,0 +1,7 @@
+{% block base_content %}
+    <div>content</div>
+{% endblock %}
+
+{% block base_footer %}
+    <div>footer</div>
+{% endblock %}

--- a/src/test/testData/inspection/TwigBlockRemovedTest/MyPlugin/Resources/views/storefront/page/content/index.html.twig
+++ b/src/test/testData/inspection/TwigBlockRemovedTest/MyPlugin/Resources/views/storefront/page/content/index.html.twig
@@ -1,0 +1,18 @@
+{# shopware-block: hash1@6.6.0.0 #}
+{% block base_content %}
+    <div>override</div>
+{% endblock %}
+
+{# shopware-block: hash2@6.6.0.0 #}
+<warning descr="The upstream block has been removed, please check if your override is still needed">{% block base_removed %}
+    <div>gone</div>
+{% endblock %}</warning>
+
+{# shopware-block: hash3@6.6.0.0 #}
+<warning descr="The upstream block has been removed from this template, but still exists in: storefront/layout/header.html.twig">{% block page_header %}
+    <div>moved</div>
+{% endblock %}</warning>
+
+{% block custom_plugin_block %}
+    <div>own block without versioning comment</div>
+{% endblock %}

--- a/src/test/testData/inspection/TwigBlockRemovedTest/ShopwarePlatform/src/Storefront/Resources/views/storefront/layout/header.html.twig
+++ b/src/test/testData/inspection/TwigBlockRemovedTest/ShopwarePlatform/src/Storefront/Resources/views/storefront/layout/header.html.twig
@@ -1,0 +1,3 @@
+{% block page_header %}
+    <div>header</div>
+{% endblock %}

--- a/src/test/testData/inspection/TwigBlockRemovedTest/ShopwarePlatform/src/Storefront/Resources/views/storefront/page/content/index.html.twig
+++ b/src/test/testData/inspection/TwigBlockRemovedTest/ShopwarePlatform/src/Storefront/Resources/views/storefront/page/content/index.html.twig
@@ -1,0 +1,3 @@
+{% block base_content %}
+    <div>content</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

Fixes #285

The twig versioning inspections (`TwigBlockHashChanged` / `TwigBlockHashMissing`) silently bail out when a block no longer exists in the upstream storefront templates, so a block that was **removed** upstream (e.g. during a 6.6 → 6.7 update) produced no notice at all — giving a false sense of update progress.

This adds a new, separate inspection `Shopware6TwigBlockRemoved` (enabled by default, WARNING severity) that checks every block carrying a `{# shopware-block: hash@version #}` comment:

- Block gone from upstream entirely → *"The upstream block has been removed, please check if your override is still needed"*
- Block gone from that template but still existing elsewhere → warning that lists the templates where it still exists (helps with blocks that were moved, common in the 6.7 header/navbar restructuring)
- No report when the upstream template index is empty (e.g. `vendor/shopware/storefront` not installed), to avoid false positives

Only blocks with a versioning comment are checked, since that comment is the reliable signal that a block overrides upstream rather than being the plugin's own block.

## Tests

- New test for the new inspection covering: block still present, block removed, block moved, own block without comment
- Added tests for the existing Twig block inspections too: `TwigBlockDeprecated`, `TwigBlockHashChanged` (reads the real hash from the index at runtime), `TwigBlockHashMissing`
- Made `TwigBlockDeprecationIndexTest` order-independent: it asserted on `getAllKeys`, which can contain stale keys from other tests sharing the JVM index storage; it now only counts keys with values in the project scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)