### PR TITLE
Restore inheritance gutter markers on Twig blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+- Restored the inheritance gutter markers on Twig blocks that were lost with the reworked Twig template handling in `0.1.0`: a block now shows an "overrides" icon when it overrides a block of the `sw_extends` chain and an "overridden" icon when extending templates override it, both navigating to the related blocks. The markers are provided by the plugin itself and no longer require the Symfony plugin. Fixes #307
+
 ## 0.1.0 - 2026-07-30
 
 - Replaced the Symfony plugin integration for `sw_extends` / `sw_include` with own navigation and autocompletion: navigating a template reference now offers all templates of that view path (the referenced bundle first, then all plugin overrides), and completion suggests templates of every bundle including plugins in `custom/plugins`

--- a/src/main/kotlin/de/shyim/shopware6/index/ShopwareTemplateExtendsIndex.kt
+++ b/src/main/kotlin/de/shyim/shopware6/index/ShopwareTemplateExtendsIndex.kt
@@ -1,0 +1,70 @@
+package de.shyim.shopware6.index
+
+import com.intellij.util.indexing.DataIndexer
+import com.intellij.util.indexing.DefaultFileTypeSpecificInputFilter
+import com.intellij.util.indexing.FileBasedIndex
+import com.intellij.util.indexing.FileBasedIndexExtension
+import com.intellij.util.indexing.FileContent
+import com.intellij.util.indexing.ID
+import com.intellij.util.io.EnumeratorStringDescriptor
+import com.intellij.util.io.KeyDescriptor
+import com.intellij.util.io.VoidDataExternalizer
+import com.jetbrains.twig.TwigFileType
+import de.shyim.shopware6.util.TwigUtil
+
+/**
+ * Reverse of [ShopwareTemplateIndex]: indexes every extending template by the view path its
+ * sw_extends tag points to. This makes the templates extending a given view path a single index
+ * lookup instead of a scan over every known template.
+ */
+class ShopwareTemplateExtendsIndex : FileBasedIndexExtension<String, Void>() {
+    override fun getName(): ID<String, Void> {
+        return key
+    }
+
+    override fun getIndexer(): DataIndexer<String, Void, FileContent> {
+        return DataIndexer { inputData ->
+            if (!inputData.file.path.contains("Resources/views/")) {
+                return@DataIndexer mapOf()
+            }
+
+            val target = TwigUtil.findExtendsTargetReference(inputData.contentAsText)
+                ?: return@DataIndexer mapOf()
+
+            // overrides reference the template by bundle ("@Storefront/..."), but at runtime they
+            // extend every template of that view path, so only the view path is indexed
+            val viewPath = target.substringAfter("/", "")
+
+            if (viewPath.isEmpty()) {
+                return@DataIndexer mapOf()
+            }
+
+            mapOf(viewPath to null)
+        }
+    }
+
+    override fun getKeyDescriptor(): KeyDescriptor<String> {
+        return EnumeratorStringDescriptor.INSTANCE
+    }
+
+    override fun getValueExternalizer(): VoidDataExternalizer {
+        return VoidDataExternalizer.INSTANCE
+    }
+
+    override fun getVersion(): Int {
+        return 1
+    }
+
+    override fun getInputFilter(): FileBasedIndex.InputFilter {
+        return object : DefaultFileTypeSpecificInputFilter(TwigFileType.INSTANCE) {
+        }
+    }
+
+    override fun dependsOnFileContent(): Boolean {
+        return true
+    }
+
+    companion object {
+        val key = ID.create<String, Void>("de.shyim.shopware6.frontend.twig_template_extends")
+    }
+}

--- a/src/main/kotlin/de/shyim/shopware6/marker/twig/TwigBlockMarker.kt
+++ b/src/main/kotlin/de/shyim/shopware6/marker/twig/TwigBlockMarker.kt
@@ -1,0 +1,67 @@
+package de.shyim.shopware6.marker.twig
+
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider
+import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
+import com.intellij.openapi.util.NotNullLazyValue
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.elementType
+import com.jetbrains.php.PhpIcons
+import com.jetbrains.twig.TwigTokenTypes
+import com.jetbrains.twig.elements.TwigBlockTag
+import de.shyim.shopware6.util.TwigUtil
+
+/**
+ * Gutter icons on {% block name %} pointing to the block it overrides and to the blocks
+ * overriding it, the same way PhpStorm marks overridden methods.
+ */
+class TwigBlockMarker : RelatedItemLineMarkerProvider() {
+    override fun collectNavigationMarkers(
+        element: PsiElement,
+        result: MutableCollection<in RelatedItemLineMarkerInfo<*>>
+    ) {
+        // the identifier leaf carries the marker, so the icon sits on the block's line
+        if (element.elementType != TwigTokenTypes.IDENTIFIER) {
+            return
+        }
+
+        val blockTag = element.parent as? TwigBlockTag ?: return
+        val blockName = blockTag.name ?: return
+
+        if (blockName != element.text) {
+            return
+        }
+
+        val file = element.containingFile.originalFile
+
+        // a template that does not extend cannot override a block. Without this check the
+        // relative path fallback of getUpstreamBlocks would report the overrides of the very
+        // same view path as upstream
+        if (TwigUtil.isExtendingTemplate(file) && TwigUtil.getUpstreamBlocks(file, blockName).isNotEmpty()) {
+            result.add(
+                NavigationGutterIconBuilder.create(PhpIcons.OVERRIDES)
+                    .setTargets(NotNullLazyValue.lazy { upstreamTargets(element, blockName) })
+                    .setTooltipText("Overrides block")
+                    .createLineMarkerInfo(element)
+            )
+        }
+
+        // the paths come from the indexes, the PSI of the extending templates is only loaded
+        // once the marker is clicked
+        if (TwigUtil.getDownstreamBlockPaths(file, blockName).isNotEmpty()) {
+            result.add(
+                NavigationGutterIconBuilder.create(PhpIcons.IMPLEMENTED)
+                    .setTargets(NotNullLazyValue.lazy { TwigUtil.getDownstreamBlocks(file, blockName) })
+                    .setTooltipText("Overridden in extending templates")
+                    .createLineMarkerInfo(element)
+            )
+        }
+    }
+
+    private fun upstreamTargets(element: PsiElement, blockName: String): Collection<PsiElement> {
+        val file = element.containingFile.originalFile
+
+        return TwigUtil.getUpstreamBlocks(file, blockName)
+            .flatMap { TwigUtil.findBlockTagsInFile(element.project, it.absolutePath, blockName) }
+    }
+}

--- a/src/main/kotlin/de/shyim/shopware6/navigation/TwigBlockGoToDeclareHandler.kt
+++ b/src/main/kotlin/de/shyim/shopware6/navigation/TwigBlockGoToDeclareHandler.kt
@@ -25,7 +25,7 @@ class TwigBlockGoToDeclareHandler : GotoDeclarationHandler {
 
         // navigate to the upstream block this one overrides, nearest parent first
         val targets = TwigUtil.getUpstreamBlocks(element.containingFile.originalFile, blockName)
-            .mapNotNull { TwigUtil.findBlockTagInFile(element.project, it.absolutePath, blockName) }
+            .mapNotNull { TwigUtil.findBlockTagsInFile(element.project, it.absolutePath, blockName).firstOrNull() }
 
         return if (targets.isEmpty()) null else targets.toTypedArray()
     }

--- a/src/main/kotlin/de/shyim/shopware6/util/ShopwareTemplateUtil.kt
+++ b/src/main/kotlin/de/shyim/shopware6/util/ShopwareTemplateUtil.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.util.indexing.FileBasedIndex
+import de.shyim.shopware6.index.ShopwareTemplateExtendsIndex
 import de.shyim.shopware6.index.ShopwareTemplateIndex
 import icons.ShopwareToolBoxIcons
 
@@ -68,6 +69,89 @@ object ShopwareTemplateUtil {
 
         return bundleMatches.sortedWith(templateOrder()) +
                 (candidates - bundleMatches.toSet()).sortedWith(templateOrder())
+    }
+
+    /**
+     * Every template extending the given one, nearest child first. Templates extending a child
+     * are collected transitively.
+     */
+    fun getTemplatesExtendingTemplate(project: Project, file: VirtualFile): List<VirtualFile> {
+        val children = LinkedHashSet<VirtualFile>()
+
+        // several extensions typically override the same view path, so every one of them
+        // references it and looks like a child of the others. The templates the file extends
+        // itself are upstream, never children
+        val visited = HashSet(getExtendsChainPaths(project, file))
+        visited.add(file.path)
+
+        var current = listOf(file)
+        var depth = 0
+
+        // a cycle is already broken by "visited", the depth limit only guards against
+        // pathologically long chains
+        while (current.isNotEmpty() && depth++ < 8) {
+            val next = ArrayList<VirtualFile>()
+
+            current.forEach { template ->
+                getDirectChildren(project, template).forEach { child ->
+                    if (visited.add(child.path)) {
+                        children.add(child)
+                        next.add(child)
+                    }
+                }
+            }
+
+            current = next
+        }
+
+        return children.toList()
+    }
+
+    /**
+     * Paths of the templates the given one extends, nearest parent first
+     */
+    fun getExtendsChainPaths(project: Project, file: VirtualFile): List<String> {
+        return followExtendsChain(project, file.path, getExtendsTarget(project, file))
+    }
+
+    /**
+     * Walks up the sw_extends chain, starting at the given target reference, nearest parent
+     * first. The targets of the parents come from the index, so no further files are loaded.
+     */
+    fun followExtendsChain(project: Project, startPath: String?, startTarget: String?): List<String> {
+        val paths = ArrayList<String>()
+        val visited = HashSet<String>()
+        startPath?.let { visited.add(it) }
+
+        var target = startTarget
+
+        while (target != null && paths.size < 10) {
+            val bundleName = target.substringBefore("/").removePrefix("@")
+            val templatePath = target.substringAfter("/", "")
+
+            if (templatePath.isEmpty()) {
+                break
+            }
+
+            val parent = findTemplateInBundle(project, bundleName, templatePath) ?: break
+
+            if (!visited.add(parent.path)) {
+                break
+            }
+
+            paths.add(parent.path)
+            target = getExtendsTarget(project, parent)
+        }
+
+        return paths
+    }
+
+    private fun getDirectChildren(project: Project, file: VirtualFile): List<VirtualFile> {
+        return FileBasedIndex.getInstance().getContainingFiles(
+            ShopwareTemplateExtendsIndex.key,
+            TwigUtil.getRelativePath(file.path),
+            GlobalSearchScope.allScope(project)
+        ).filter { it.path != file.path }.sortedWith(templateOrder())
     }
 
     fun getTemplateLookupElements(project: Project): List<LookupElement> {

--- a/src/main/kotlin/de/shyim/shopware6/util/TwigUtil.kt
+++ b/src/main/kotlin/de/shyim/shopware6/util/TwigUtil.kt
@@ -10,6 +10,9 @@ import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.util.indexing.FileBasedIndex
 import com.jetbrains.php.composer.actions.update.ComposerInstalledPackagesService
 import com.jetbrains.twig.TwigFileType
@@ -74,48 +77,30 @@ object TwigUtil {
     }
 
     fun getExtendsChainPaths(file: PsiFile): List<String> {
-        val project = file.project
-        val paths = ArrayList<String>()
-        val visited = HashSet<String>()
-        file.originalFile.virtualFile?.path?.let { visited.add(it) }
-
-        var target = findExtendsTargetReference(file.text)
-
-        while (target != null && paths.size < 10) {
-            val bundleName = target.substring(1).substringBefore("/")
-            val templatePath = target.substringAfter("/", "")
-
-            if (templatePath.isEmpty()) {
-                break
-            }
-
-            val parent = ShopwareTemplateUtil.findTemplateInBundle(project, bundleName, templatePath) ?: break
-
-            if (!visited.add(parent.path)) {
-                break
-            }
-
-            paths.add(parent.path)
-
-            // the parents' extends targets come from the index, so no further files need to be loaded
-            target = ShopwareTemplateUtil.getExtendsTarget(project, parent)
+        // cached per file, as every block of a template walks the same chain
+        return CachedValuesManager.getCachedValue(file) {
+            CachedValueProvider.Result.create(
+                // the first target is read from the PSI so that unsaved edits are respected
+                ShopwareTemplateUtil.followExtendsChain(
+                    file.project,
+                    file.originalFile.virtualFile?.path,
+                    findExtendsTargetReference(file.text)
+                ),
+                PsiModificationTracker.MODIFICATION_COUNT
+            )
         }
-
-        return paths
     }
 
-    fun findBlockTagInFile(project: Project, path: String, blockName: String): PsiElement? {
-        val virtualFile = ShopwareTemplateUtil.findTemplateByPath(project, path) ?: return null
+    fun findBlockTagsInFile(project: Project, path: String, blockName: String): List<PsiElement> {
+        val virtualFile = ShopwareTemplateUtil.findTemplateByPath(project, path) ?: return emptyList()
+        val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: return emptyList()
 
-        val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: return null
-
-        var blockTag: PsiElement? = null
+        val blockTags = ArrayList<PsiElement>()
 
         psiFile.acceptChildren(object : PsiRecursiveElementWalkingVisitor() {
             override fun visitElement(element: PsiElement) {
                 if (element is TwigBlockTag && element.name == blockName) {
-                    blockTag = element
-                    stopWalking()
+                    blockTags.add(element)
                     return
                 }
 
@@ -123,7 +108,55 @@ object TwigUtil {
             }
         })
 
-        return blockTag
+        return blockTags
+    }
+
+    /**
+     * Paths of the templates extending the given file, nearest child first. Cached per file, as
+     * every block of a template resolves the same set.
+     */
+    fun getExtendingTemplatePaths(file: PsiFile): List<String> {
+        return CachedValuesManager.getCachedValue(file) {
+            val virtualFile = file.originalFile.virtualFile
+
+            CachedValueProvider.Result.create(
+                if (virtualFile == null) {
+                    emptyList()
+                } else {
+                    ShopwareTemplateUtil.getTemplatesExtendingTemplate(file.project, virtualFile)
+                        .map { it.path }
+                },
+                PsiModificationTracker.MODIFICATION_COUNT
+            )
+        }
+    }
+
+    /**
+     * Paths of the templates extending the given file which define a block of the given name,
+     * nearest child first. Resolved from the indexes only, so it is cheap enough to decide
+     * whether a gutter marker is shown.
+     */
+    fun getDownstreamBlockPaths(file: PsiFile, blockName: String): List<String> {
+        val extending = getExtendingTemplatePaths(file)
+
+        if (extending.isEmpty()) {
+            return emptyList()
+        }
+
+        val paths = FileBasedIndex.getInstance()
+            .getValues(TwigBlockHashIndex.key, blockName, GlobalSearchScope.allScope(file.project))
+            .mapTo(HashSet()) { it.absolutePath }
+
+        return extending.filter { paths.contains(it) }
+    }
+
+    /**
+     * Every block of the given name in templates extending the given file, nearest child first
+     */
+    fun getDownstreamBlocks(file: PsiFile, blockName: String): List<PsiElement> {
+        val project = file.project
+
+        return getDownstreamBlockPaths(file, blockName).flatMap { findBlockTagsInFile(project, it, blockName) }
     }
 
     fun getUpstreamBlocks(file: PsiFile, blockName: String): List<TwigBlockHash> {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,6 +41,7 @@
         <fileBasedIndex implementation="de.shyim.shopware6.index.TwigBlockDeprecationIndex"/>
         <fileBasedIndex implementation="de.shyim.shopware6.index.TwigBlockHashIndex"/>
         <fileBasedIndex implementation="de.shyim.shopware6.index.ShopwareTemplateIndex"/>
+        <fileBasedIndex implementation="de.shyim.shopware6.index.ShopwareTemplateExtendsIndex"/>
 
         <gotoDeclarationHandler implementation="de.shyim.shopware6.navigation.FeatureFlagGoToDeclareHandler"/>
         <gotoDeclarationHandler implementation="de.shyim.shopware6.navigation.AdminComponentGoToDeclareHandler"/>
@@ -263,6 +264,7 @@
         </intentionAction>
 
         <codeInsight.lineMarkerProvider implementationClass="de.shyim.shopware6.marker.js.AdminComponentMarker" language="JavaScript"/>
+        <codeInsight.lineMarkerProvider implementationClass="de.shyim.shopware6.marker.twig.TwigBlockMarker" language="Twig"/>
         <gotoSymbolContributor implementation="de.shyim.shopware6.navigation.symbol.AdminComponentSymbolContributor"/>
 
         <notificationGroup id="Shopware"

--- a/src/test/kotlin/de/shyim/shopware6/test/marker/TwigBlockMarkerTest.kt
+++ b/src/test/kotlin/de/shyim/shopware6/test/marker/TwigBlockMarkerTest.kt
@@ -1,0 +1,103 @@
+package de.shyim.shopware6.test.marker
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo
+import com.intellij.psi.PsiElement
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class TwigBlockMarkerTest : BasePlatformTestCase() {
+    private val corePath =
+        "ShopwarePlatform/src/Storefront/Resources/views/storefront/page/content/index.html.twig"
+    private val pluginPath = "MyPlugin/Resources/views/storefront/page/content/index.html.twig"
+    private val themePath =
+        "custom/plugins/TcinnTheme/src/Resources/views/storefront/page/content/index.html.twig"
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.copyDirectoryToProject("ShopwarePlatform", "ShopwarePlatform")
+        myFixture.copyDirectoryToProject("MyPlugin", "MyPlugin")
+        myFixture.copyDirectoryToProject("custom", "custom")
+    }
+
+    override fun getTestDataPath(): String {
+        return "src/test/testData/marker/TwigBlockMarkerTest/"
+    }
+
+    fun testUpstreamBlockIsOnlyMarkedAsOverridden() {
+        // the core template extends nothing, so it can only be overridden
+        assertEquals(listOf("Overridden in extending templates"), tooltipsOf(corePath))
+    }
+
+    fun testBlockInTheMiddleOfTheChainIsMarkedInBothDirections() {
+        assertEquals(
+            listOf("Overrides block", "Overridden in extending templates"),
+            tooltipsOf(pluginPath)
+        )
+    }
+
+    fun testLastOverrideOfTheChainIsOnlyMarkedAsOverriding() {
+        // the theme is the last template of the chain, the plugin it extends is upstream and
+        // must not be reported as an override of it
+        assertEquals(listOf("Overrides block"), tooltipsOf(themePath))
+    }
+
+    fun testBlockWithoutRelatedBlocksHasNoMarker() {
+        openFile(corePath)
+
+        val untouchedLine = lineOfText("base_untouched")
+
+        assertTrue(markers().none { line(it) == untouchedLine })
+    }
+
+    fun testOverridesMarkerNavigatesUpTheChain() {
+        openFile(themePath)
+
+        val paths = targetsOf("Overrides block").map { it.containingFile.virtualFile.path }
+
+        // the whole chain is offered, nearest parent first
+        assertEquals(2, paths.size)
+        assertTrue(paths[0].contains("/MyPlugin/"))
+        assertTrue(paths[1].contains("ShopwarePlatform"))
+    }
+
+    fun testOverriddenMarkerNavigatesToEveryOverride() {
+        openFile(corePath)
+
+        val paths = targetsOf("Overridden in extending templates")
+            .map { it.containingFile.virtualFile.path }
+
+        assertEquals(2, paths.size)
+        assertTrue(paths.any { it.contains("/MyPlugin/") })
+        assertTrue(paths.any { it.contains("TcinnTheme") })
+    }
+
+    private fun openFile(path: String) {
+        myFixture.configureFromExistingVirtualFile(myFixture.findFileInTempDir(path))
+    }
+
+    private fun tooltipsOf(path: String): List<String> {
+        openFile(path)
+
+        return markers().mapNotNull { it.lineMarkerInfo.lineMarkerTooltip }
+    }
+
+    private fun targetsOf(tooltip: String): Collection<PsiElement> {
+        val marker = markers().first { it.lineMarkerInfo.lineMarkerTooltip == tooltip }
+
+        return (marker.lineMarkerInfo as RelatedItemLineMarkerInfo<*>).createGotoRelatedItems()
+            .mapNotNull { it.element }
+    }
+
+    private fun markers(): List<LineMarkerInfo.LineMarkerGutterIconRenderer<*>> {
+        return myFixture.findAllGutters()
+            .filterIsInstance<LineMarkerInfo.LineMarkerGutterIconRenderer<*>>()
+    }
+
+    private fun line(marker: LineMarkerInfo.LineMarkerGutterIconRenderer<*>): Int {
+        return myFixture.editor.document.getLineNumber(marker.lineMarkerInfo.startOffset)
+    }
+
+    private fun lineOfText(text: String): Int {
+        return myFixture.editor.document.text.lineSequence().indexOfFirst { it.contains(text) }
+    }
+}

--- a/src/test/testData/marker/TwigBlockMarkerTest/MyPlugin/Resources/views/storefront/page/content/index.html.twig
+++ b/src/test/testData/marker/TwigBlockMarkerTest/MyPlugin/Resources/views/storefront/page/content/index.html.twig
@@ -1,0 +1,5 @@
+{% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
+
+{% block base_content %}
+    <div>plugin override</div>
+{% endblock %}

--- a/src/test/testData/marker/TwigBlockMarkerTest/ShopwarePlatform/src/Storefront/Resources/views/storefront/page/content/index.html.twig
+++ b/src/test/testData/marker/TwigBlockMarkerTest/ShopwarePlatform/src/Storefront/Resources/views/storefront/page/content/index.html.twig
@@ -1,0 +1,7 @@
+{% block base_content %}
+    <div>content</div>
+{% endblock %}
+
+{% block base_untouched %}
+    <div>nobody overrides this</div>
+{% endblock %}

--- a/src/test/testData/marker/TwigBlockMarkerTest/custom/plugins/TcinnTheme/src/Resources/views/storefront/page/content/index.html.twig
+++ b/src/test/testData/marker/TwigBlockMarkerTest/custom/plugins/TcinnTheme/src/Resources/views/storefront/page/content/index.html.twig
@@ -1,0 +1,5 @@
+{% sw_extends '@MyPlugin/storefront/page/content/index.html.twig' %}
+
+{% block base_content %}
+    <div>theme override</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

Fixes #307

The Symfony plugin used to show inheritance gutter markers on Twig blocks. After 0.1.0 replaced that integration with native `sw_extends` navigation, the markers disappeared.

This restores them as a plugin-owned `RelatedItemLineMarkerProvider` on `{% block name %}`:

- **Overrides** (up the chain): shown when the template extends another one and the same block exists upstream. Clicking navigates to those blocks, nearest parent first.
- **Overridden** (down the chain): shown when other templates extending this one define the same block. Clicking navigates to those overrides.

Sibling templates that all write `@Storefront/...` are not treated as children of each other. Downstream resolution uses a reverse `sw_extends` index (`ShopwareTemplateExtendsIndex`) plus the existing block index, so deciding whether to show a marker does not load other templates' PSI.

`TwigUtil.getExtendsChainPaths` is now cached per file, since every block of a template walks the same chain.

## Tests

`TwigBlockMarkerTest` covers:

- core template only marked as overridden
- plugin in the middle of the chain marked in both directions
- last override (theme) only marked as overriding, not as a child of its siblings
- a block with no related blocks has no marker
- overrides marker navigates up the whole chain, nearest parent first
- overridden marker navigates to every override
